### PR TITLE
fix gitignore ENOENT showstopper

### DIFF
--- a/scripts/build-static.js
+++ b/scripts/build-static.js
@@ -7,10 +7,13 @@ const mkdirp = require('mkdirp')
 const parallelLimit = require('run-parallel-limit')
 
 var cwd = process.cwd()
+var gitignore = []
 
-var gitignore = fs.readFileSync(path.join(cwd, '.gitignore'), 'utf8')
-  .split('\n')
-  .filter(s => s.length && s.slice(0, 1) !== '#')
+try {
+  gitignore = fs.readFileSync(path.join(cwd, '.gitignore'), 'utf8')
+    .split('\n')
+    .filter(s => s.length && s.slice(0, 1) !== '#')
+} catch (e) {}
 
 module.exports = buildStatic
 

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -8,10 +8,13 @@ const convertFile = require('./convert-file')
 const config = require('../lib/config')
 
 var cwd = process.cwd()
+var gitignore = []
 
-var gitignore = fs.readFileSync(path.join(cwd, '.gitignore'), 'utf8')
-  .split('\n')
-  .filter(s => s.length && s.slice(0, 1) !== '#')
+try {
+  gitignore = fs.readFileSync(path.join(cwd, '.gitignore'), 'utf8')
+    .split('\n')
+    .filter(s => s.length && s.slice(0, 1) !== '#')
+} catch (e) {}
 
 module.exports = function watch () {
   debug('watching:', config.content_dir)


### PR DESCRIPTION
This PR fixes `static` and `serve` tasks erroring out when there's no `.gitignore` file present in the working directory.

<details>
<summary>

stack trace `Error: ENOENT`</summary>



```
~/dev/example $ npm run start

> example@1.0.0-alpha start /Users/ngoldman/dev/example
> yo-static serve

fs.js:584
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open '/Users/ngoldman/dev/example/.gitignore'
    at Error (native)
    at Object.fs.openSync (fs.js:584:18)
    at Object.fs.readFileSync (fs.js:431:33)
    at Object.<anonymous> (/Users/ngoldman/dev/github/yo-static/scripts/watch.js:12:20)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:20:19)
```

</details>

This solves the issue by stupidly wrapping both gitignore `fs.readFileSync` calls in a try catch since there's no other way to catch errors from the sync version of `fs.readFile`. Eventually it would be good move this logic into one file since it's identical in both places.
